### PR TITLE
Added second argument to BitmapFactory.decodeFile

### DIFF
--- a/app/src/main/java/com/example/android/emojify/BitmapUtils.java
+++ b/app/src/main/java/com/example/android/emojify/BitmapUtils.java
@@ -71,7 +71,7 @@ class BitmapUtils {
         bmOptions.inJustDecodeBounds = false;
         bmOptions.inSampleSize = scaleFactor;
 
-        return BitmapFactory.decodeFile(imagePath);
+        return BitmapFactory.decodeFile(imagePath, bmOptions);
     }
 
     /**


### PR DESCRIPTION
Without this change, "resamplePic" method is useless and image is not scaled at all.