### PR TITLE
Apply bitmap options to reflect scalefactor while decoding image

### DIFF
--- a/app/src/main/java/com/example/android/emojify/BitmapUtils.java
+++ b/app/src/main/java/com/example/android/emojify/BitmapUtils.java
@@ -71,7 +71,7 @@ class BitmapUtils {
         bmOptions.inJustDecodeBounds = false;
         bmOptions.inSampleSize = scaleFactor;
 
-        return BitmapFactory.decodeFile(imagePath);
+        return BitmapFactory.decodeFile(imagePath, bmOptions);
     }
 
     /**


### PR DESCRIPTION
Currently bitmap options are not used for decoding at final decoding step, which defeats the purpose of resamplePic method in BitmapUtils.java class. This is fixed in this pull request.